### PR TITLE
Add support for cdn video downloads and new france (fun) mooc

### DIFF
--- a/edx-dl.py
+++ b/edx-dl.py
@@ -315,6 +315,11 @@ def main():
     else:
         links = weeks[w_number - 1][1]
 
+    target_dir = os.path.join(args.output_dir,
+                              directory_name(selected_course[0]))
+    if not os.path.exists(target_dir):
+        os.makedirs(target_dir)
+
     video_id = []
     subsUrls = []
     regexpSubs = re.compile(r'data-transcript-translation-url=(?:&#34;|")([^"&]*)(?:&#34;|")')
@@ -354,8 +359,6 @@ def main():
     c = 0
     for v, s in zip(video_link, subsUrls):
         c += 1
-        target_dir = os.path.join(args.output_dir,
-                                  directory_name(selected_course[0]))
         filename_prefix = str(c).zfill(2)
         cmd = ["youtube-dl",
                "-o", os.path.join(target_dir, filename_prefix + "-%(title)s.%(ext)s")]

--- a/edx-dl.py
+++ b/edx-dl.py
@@ -259,7 +259,6 @@ def main():
     dash = get_page_contents(DASHBOARD, headers)
     soup = BeautifulSoup(dash)
     data = soup.find_all('ul')[1]
-    USERNAME = data.find_all('span')[1].string
     COURSES = soup.find_all('article', 'course')
     courses = []
     for COURSE in COURSES:
@@ -273,8 +272,6 @@ def main():
     numOfCourses = len(courses)
 
     # Welcome and Choose Course
-
-    print('Welcome %s' % USERNAME)
     print('You can access %d courses' % numOfCourses)
 
     c = 0
@@ -352,8 +349,6 @@ def main():
         args.format = input('Choose Format code: ')
 
         args.subtitles = input('Download subtitles (y/n)? ').lower() == 'y'
-
-    print("[info] Output directory: " + args.output_dir)
 
     # Download Videos
     c = 0

--- a/edx-dl.py
+++ b/edx-dl.py
@@ -60,6 +60,10 @@ OPENEDX_SITES = {
         'url': 'https://class.stanford.edu',
         'courseware-selector': ('section', {'aria-label':'Course Navigation'}),
     },
+    'fun': {
+        'url': 'https://www.france-universite-numerique-mooc.fr',
+        'courseware-selector': ('section', {'aria-label': 'Menu du cours'}),
+    },
 }
 BASE_URL = OPENEDX_SITES['edx']['url']
 EDX_HOMEPAGE = BASE_URL + '/login_ajax'


### PR DESCRIPTION
Addressing partially issue #95

I tried to do the less aggresive refactoring possible to enable the support, notice that subtitles are not supported for the moment in the case the downloads are made from the CDN URL, We need to handle sections in a more organized fashion to support this, as well as appropriate video renaming.