### PR TITLE
Section prefix for downloads and option for selecting multiple weeks at once

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 semantic.cache
 Downloaded/
 *~
+.*.swp

--- a/edx-dl.py
+++ b/edx-dl.py
@@ -260,6 +260,12 @@ def main():
         args.username = input('Username: ')
         args.password = getpass.getpass()
 
+    # If just the password is missing, query it interactively. This allows to
+    # specify everything else on the command line without having your password
+    # saved in the history.
+    if None == args.password:
+        args.password = getpass.getpass()
+
     change_openedx_site(args.platform)
 
     if not args.username or not args.password:

--- a/edx-dl.py
+++ b/edx-dl.py
@@ -361,7 +361,7 @@ def main():
         id_container = splitter.split(page)[1:]
         video_id += [link[:YOUTUBE_VIDEO_ID_LENGTH] for link in
                      id_container]
-        subsUrls += [BASE_URL + regexpSubs.search(container).group(2) + "?videoId=" + id + "&language=en"
+        subsUrls += [BASE_URL + regexpSubs.search(container).group(1) + "?videoId=" + id + "&language=en"
                      if regexpSubs.search(container) is not None else ''
                      for id, container in zip(video_id[-len(id_container):], id_container)]
         # Try to download some extra videos which is referred by iframe


### PR DESCRIPTION
I've added the option to select multiple weeks at once for downloading and a section prefix to the download names. This allows to conveniently create download batches between a single week and all videos. The section prefixes maintain a consistent naming across the downloaded files when downloading individual weeks.

Enter multiple week numbers separated by whitespaces:

    1 - Download Welcome videos
    [...]
    13 - Download them all
    Enter Your Choice: 12 1 8

Or just a single one maintaining compatibility with the previous prompt. The videos will be named as follows:

    01-01-0_WEEK_INTRO.mp4
    08-01-3_WEEK_INTRO.mp4
    08-02-3_wk_orthogonal_bases_01.mp4
    [...]

This branch includes 691c607 which was required for me to get e0c7184 working.