### PR TITLE
Danmbox2

### DIFF
--- a/edx-dl.py
+++ b/edx-dl.py
@@ -443,6 +443,8 @@ def get_filename(target_dir, filename_prefix):
         if name.startswith(filename_prefix):
             (basename, ext) = os.path.splitext(name)
             return basename
+    print('[warning] no video downloaded for %s' % filename_prefix)
+    return filename_prefix
 
 if __name__ == '__main__':
     try:

--- a/edx-dl.py
+++ b/edx-dl.py
@@ -97,10 +97,10 @@ def print(*objects, **kwargs):
     texts = []
     for object in objects:
         try:
-            original_text = str(object)
+            original_text = str(object).decode(enc, errors='replace')
         except UnicodeEncodeError:
-            original_text = unicode(object)
-        texts.append(original_text.encode(enc, errors='replace').decode(enc))
+            original_text = unicode(object).encode(enc, errors='replace').decode(enc, errors='replace')
+        texts.append(original_text)
     return __builtins__.print(*texts, **kwargs)
 
 def change_openedx_site(site_name):


### PR DESCRIPTION
Fixed the following:
* print() sometimes fails due to attempting to encode() strings (which causes an implicit decoding which sometimes fails)
* script fails when there is no video but there is a subtitle