### PR TITLE
Fix for #137, unable to locate DOM elements when user language is not 'English'

### DIFF
--- a/edx-dl.py
+++ b/edx-dl.py
@@ -331,7 +331,12 @@ def main():
     soup = BeautifulSoup(courseware)
 
     data = soup.find(*COURSEWARE_SEL)
-    WEEKS = data.find_all('div')
+
+    if not data:
+        WEEKS = soup.find_all('div', attrs={'class': 'chapter'})
+    else:
+        WEEKS = data.find_all('div')
+
     weeks = [(w.h3.a.string, [BASE_URL + a['href'] for a in
              w.ul.find_all('a')]) for w in WEEKS]
     numOfWeeks = len(weeks)

--- a/edx-dl.py
+++ b/edx-dl.py
@@ -146,6 +146,19 @@ def get_initial_token():
 
     return ''
 
+def get_available_weeks(courseware):
+    soup = BeautifulSoup(courseware)
+    data = soup.find(*COURSEWARE_SEL)
+
+    if not data:
+        WEEKS = soup.find_all('div', attrs={'class': 'chapter'})
+    else:
+        WEEKS = data.find_all('div')
+
+    weeks = [(w.h3.a.string, [BASE_URL + a['href'] for a in
+             w.ul.find_all('a')]) for w in WEEKS]
+
+    return weeks
 
 def get_page_contents(url, headers):
     """
@@ -328,17 +341,7 @@ def main():
 
     # Get Available Weeks
     courseware = get_page_contents(COURSEWARE, headers)
-    soup = BeautifulSoup(courseware)
-
-    data = soup.find(*COURSEWARE_SEL)
-
-    if not data:
-        WEEKS = soup.find_all('div', attrs={'class': 'chapter'})
-    else:
-        WEEKS = data.find_all('div')
-
-    weeks = [(w.h3.a.string, [BASE_URL + a['href'] for a in
-             w.ul.find_all('a')]) for w in WEEKS]
+    weeks = get_available_weeks(courseware)
     numOfWeeks = len(weeks)
 
     # Choose Week or choose all


### PR DESCRIPTION
According to #137

The **courseware selector** will fail on other non-English users because the value of *aria-label* is based on the [PREFERRED LANGUAGE] of the user's edX account.

For example, as a Chinese I got a aria-label with value '课程导航' instead of 'Course Navigation'

Instead of enumerating all the cases of different language, I think we may use the class-selector to locate the DOM objects. Since all **\<div\>** elements inside **\<nav\>**  have the same class name **'chapter'**.



![image](https://cloud.githubusercontent.com/assets/1549211/6570992/fb1109f4-c73d-11e4-9c9c-769fbe0edcdb.png)
