### PR TITLE
Add authors file

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,19 @@
+# Introduction
+
+In no lexicographic/alphabetical order, this file lists authors and
+contributors to the project.  It is meant to recognize and credit their
+contributions to the project.
+
+Introduction of names in this file is completely voluntary, as some people
+may not want to be included given their potential employment requirements or
+other issues. We respect the contributor's wishes.
+
+To be included in this file, just send a pull request with your name, once
+you have at least one contribution to the project.
+
+# Contributors
+
+* Emad Shaaban
+* George Monkey
+* Ismaël Mejía
+* Rogério Theodoro de Brito

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ edX](https://github.com/edx/edx-platform/wiki/Sites-powered-by-Open-edX). Feel f
 
 # Authors
 
-The original file was written by @shk3 in/for `python3` then updated
-by @emadshaaban92 for python2, and migrated for versions superior to
-2.6 by @iemejia.
+See the contributors to the project in the [AUTHORS.md][authors] file.  If
+you have contributed to the project, we would like to gladly credit you for
+your work. Just send us a note to be added to that list.
+
+[authors]: https://github.com/shk3/edx-downloader/blob/master/AUTHORS.md


### PR DESCRIPTION
This commit adds an `AUTHORS.md` (this was copied from `coursera-dl`; I hope that no reference to that project remains) file with the names of the authors and/or contributors to the project.

Please, consider merging and, also, including other names to credit people.


Thanks,

Rogério Brito.
