### PR TITLE
Support folders per section as default download method

### DIFF
--- a/edx_dl/edx_dl.py
+++ b/edx_dl/edx_dl.py
@@ -591,8 +591,9 @@ def main():
                     cmd.extend(args.youtube_options.split())
                     cmd.append(unit.video_youtube_url)
                     execute_command(cmd)
+
                 if args.subtitles:
-                    filename = get_filename(target_dir, filename_prefix)
+                    filename = get_filename_from_prefix(target_dir, filename_prefix)
                     if filename is None:
                         _print('[warning] no video downloaded for %s' % filename_prefix)
                         continue
@@ -608,7 +609,7 @@ def main():
                             _print('[info] Skipping existing edX subtitle %s' % subs_filename)
 
 
-def get_filename(target_dir, filename_prefix):
+def get_filename_from_prefix(target_dir, filename_prefix):
     """
     Return the basename for the corresponding filename_prefix.
     """

--- a/edx_dl/edx_dl.py
+++ b/edx_dl/edx_dl.py
@@ -571,16 +571,17 @@ def main():
     # sections/subsections to add correct prefixes and shows nicer information
     video_format_option = args.format + '/mp4' if args.format else 'mp4'
     subtitles_option = '--all-subs' if args.subtitles else ''
-    counter = 0
-    for i, selected_section in enumerate(selected_sections, 1):
-        for j, subsection in enumerate(selected_section.subsections, 1):
+    coursename = directory_name(selected_course.name)
+    for selected_section in selected_sections:
+        section_dirname = str(selected_section.position).zfill(2) + '-' + directory_name(selected_section.name)
+        target_dir = os.path.join(args.output_dir, coursename, section_dirname)
+        counter = 0
+        for subsection in selected_section.subsections:
             units = all_units.get(subsection.url, [])
             for unit in units:
                 counter += 1
+                filename_prefix = str(counter).zfill(2)
                 if unit.video_youtube_url is not None:
-                    coursename = directory_name(selected_course.name)
-                    target_dir = os.path.join(args.output_dir, coursename)
-                    filename_prefix = str(counter).zfill(2)
                     filename = filename_prefix + "-%(title)s.%(ext)s"
                     fullname = os.path.join(target_dir, filename)
 

--- a/edx_dl/edx_dl.py
+++ b/edx_dl/edx_dl.py
@@ -7,6 +7,7 @@ import json
 import os
 import os.path
 import re
+import string
 import subprocess
 import sys
 
@@ -215,17 +216,24 @@ def get_page_contents(url, headers):
     return result.read().decode(charset)
 
 
+def strip_non_ascii_chars(str):
+    """
+    Strips the non ascii characters from a str
+    """
+    allowed_chars = string.digits + string.ascii_letters + " _."
+    result = ""
+    for ch in str:
+        if allowed_chars.find(ch) != -1:
+            result += ch
+    return result
+
+
 def directory_name(initial_name):
     """
     Transform the name of a directory into an ascii version
     """
-    import string
-    allowed_chars = string.digits + string.ascii_letters + " _."
-    result_name = ""
-    for ch in initial_name:
-        if allowed_chars.find(ch) != -1:
-            result_name += ch
-    return result_name if result_name != "" else "course_folder"
+    result = strip_non_ascii_chars(initial_name)
+    return result if result != "" else "course_folder"
 
 
 def edx_json2srt(o):


### PR DESCRIPTION
Resources are downloaded now to section folders as default.
    
I decided to make this a default since it is way clearer for both
the users and the developers, additionally it is the same behavior
that coursera-dl does.
