### PR TITLE
Force html5lib with bs4

### DIFF
--- a/edx_dl/edx_dl.py
+++ b/edx_dl/edx_dl.py
@@ -56,7 +56,12 @@ from functools import partial
 from multiprocessing.dummy import Pool as ThreadPool
 from subprocess import Popen, PIPE
 
-from bs4 import BeautifulSoup
+import html5lib
+
+from bs4 import BeautifulSoup as BeautifulSoup_
+# Force use of bs4 with html5lib
+BeautifulSoup = lambda page: BeautifulSoup_(page, 'html5lib')
+
 
 OPENEDX_SITES = {
     'edx': {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 beautifulsoup4>=4.1.3
+html5lib>=1.0b2
+six>=1.5.0

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,8 @@ downloadcache = .tox/_download/
 
 deps =
     beautifulsoup4>=4.1.3
+    html5lib>=1.0b2
     pytest>=2.5
+    six>=1.5.0
 
 commands = py.test -v --junitxml={envlogdir}/result.xml .


### PR DESCRIPTION
This updates the dependencies and code to force bs4 to use html5lib.

This is the same trick that we use with coursera-dl.

It should fix #192 if I understood the situation correctly, but, please, test it before merging.


Thanks,

Rogério Brito.
