### PR TITLE
Interactive password

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 semantic.cache
 Downloaded/
 *~
+.*.swp
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/edx_dl/edx_dl.py
+++ b/edx_dl/edx_dl.py
@@ -7,6 +7,7 @@ It corresponds to the cli interface
 """
 
 import argparse
+import getpass
 import json
 import os
 import pickle
@@ -214,7 +215,6 @@ def parse_args():
 
     parser.add_argument('-p',
                         '--password',
-                        required=True,
                         action='store',
                         help='your edX password')
 
@@ -781,6 +781,11 @@ def main():
     args = parse_args()
 
     change_openedx_site(args.platform)
+
+
+    # Query password, if not alredy passed by command line.
+    if not args.password:
+        args.password = getpass.getpass(stream = sys.stderr)
 
     if not args.username or not args.password:
         compat_print("You must supply username and password to log-in")


### PR DESCRIPTION
As a late follow-up to #130 I'd like to contribute the semi-interactive password query again. It allows to interactively just enter the password so that it does not appear in the command line history or the process list where it could be seen by other users.

Using `stderr` for the password prompt makes it usable even in the case of standard output redirection.